### PR TITLE
Fix baseURL + path handling

### DIFF
--- a/TBHTTP.podspec
+++ b/TBHTTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name                = 'TBHTTP'
-  spec.version             = '0.0.11'
+  spec.version             = '0.0.12'
   spec.license             = { :type => 'MIT' }
   spec.homepage            = 'https://github.com/mosobase/TBHTTP'
   spec.authors             = { 'Marcus Osobase' => 'marcus@tunnelbear.com' }

--- a/TBHTTP/TBHTTPSessionManager.m
+++ b/TBHTTP/TBHTTPSessionManager.m
@@ -70,18 +70,12 @@
 - (void)POST:(NSString *)path parameters:(NSDictionary *)parameters
   completion:(TBHTTPCompletion)completion
 {
-  NSURL *requestURL;
-  
-  if (self.baseURL)
-    requestURL = [NSURL URLWithString:path relativeToURL: self.baseURL];
-  else
-    requestURL = [NSURL URLWithString:path];
-  
-  
   NSError *serializationError = nil;
   NSURLRequest *request =
-  [self.requestSerializer requestWithURL:requestURL method:@"POST"
-                              parameters:parameters error:&serializationError];
+    [self.requestSerializer requestWithURL: [self requestURLWithPath: path]
+                                    method: @"POST"
+                                parameters: parameters
+                                     error: &serializationError];
   
   if (serializationError)
   {
@@ -95,18 +89,12 @@
 -  (void)GET:(NSString *)path parameters:(NSDictionary *)parameters
   completion:(TBHTTPCompletion)completion
 {
-  NSURL *requestURL;
-  
-  if (self.baseURL)
-    requestURL = [NSURL URLWithString:path relativeToURL: self.baseURL];
-  else
-    requestURL = [NSURL URLWithString:path];
-  
-  
   NSError *serializationError = nil;
   NSURLRequest *request =
-  [self.requestSerializer requestWithURL:requestURL method:@"GET"
-                              parameters:parameters error:&serializationError];
+    [self.requestSerializer requestWithURL: [self requestURLWithPath: path]
+                                    method: @"GET"
+                                parameters: parameters
+                                     error: &serializationError];
   
   if (serializationError)
   {
@@ -158,6 +146,21 @@
                 logLevel:(TBLogLevel)logLevel
 {
   [super routeLogsToBlock:logger logLevel:logLevel];
+}
+
+//------------------------------------------------------------------------
+#pragma mark - Private Methods
+
+- (NSURL *)requestURLWithPath: (NSString *)path
+{
+  if (self.baseURL) {
+    return
+      [NSURL URLWithString:
+        [self.baseURL.absoluteString stringByAppendingPathComponent: path]];
+  }
+  else {
+    return [NSURL URLWithString: path];
+  }
 }
 
 @end


### PR DESCRIPTION
Workaround for URLWithString:relativeToURL: truncating baseURL components…when dealing with path starting with leading slash. 

URLWithString:relativeToURL: works according to [RFC1808](https://tools.ietf.org/html/rfc1808) which means that in the following situation:

base: http://tunnel.bears/are
path: /awesome

result will be http://tunnel.bears/awesome, which is counter-intuitive

In constrast, NSString's stringByAppendingPathComponent handles this situation reasonably. 